### PR TITLE
chore: remove unneeded clause

### DIFF
--- a/lib/hydra_srt_web/controllers/page_controller.ex
+++ b/lib/hydra_srt_web/controllers/page_controller.ex
@@ -7,10 +7,6 @@ defmodule HydraSrtWeb.PageController do
     |> halt()
   end
 
-  def index(conn, %{"path" => _path}) do
-    serve_index_html(conn)
-  end
-
   def index(conn, _params) do
     serve_index_html(conn)
   end


### PR DESCRIPTION
That clause is already handled by subsequent clause, so no point in
duplication.
