### PR TITLE
fix: remove expensive unneeded code

### DIFF
--- a/lib/hydra_srt/db.ex
+++ b/lib/hydra_srt/db.ex
@@ -737,9 +737,6 @@ defmodule HydraSrt.Db do
       source_ids == [] ->
         {:error, :invalid_source_order}
 
-      map_size(Map.new(Enum.with_index(source_ids))) != length(source_ids) ->
-        {:error, :invalid_source_order}
-
       existing_ids != requested_ids ->
         {:error, :invalid_source_order}
 


### PR DESCRIPTION
This code will always return `false` as the generated map will always
have as much keys as there is in input list.
