### PR TITLE
chore(security): add sobelow

### DIFF
--- a/.agents/skills/hydra-dev/SKILL.md
+++ b/.agents/skills/hydra-dev/SKILL.md
@@ -35,7 +35,7 @@ Actionable dev and test commands for HydraSRT. Stable reference: `AGENTS.md`, `t
 ```bash
 mix q
 # or: mix quality
-# format --check-formatted, compile --warnings-as-errors, credo, dialyzer
+# format --check-formatted, compile --warnings-as-errors, credo, sobelow, dialyzer
 ```
 
 First-time Dialyzer: `mix dialyzer` (builds PLT).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
       run: mix compile --warnings-as-errors
     - name: Check Formatting
       run: mix format --check-formatted
+    - name: Run Sobelow
+      run: mix sobelow
     - name: Run Tests
       run: mix test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ HydraSRT is an open-source SRT routing platform. The Elixir layer manages routes
 
 ### Quality (`mix q`)
 
-Runs, in order: format check, compile with warnings as errors, Credo, Dialyzer.
+Runs, in order: format check, compile with warnings as errors, Credo, Sobelow, Dialyzer.
 
 One-time Dialyzer setup (if PLT is missing):
 

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ test_ci_local:
 	MIX_ENV=test mix deps.compile
 	MIX_ENV=test mix compile --warnings-as-errors
 	MIX_ENV=test mix format --check-formatted
+	MIX_ENV=test mix sobelow
 	MIX_ENV=test mix test
 	@echo "6/6 Elixir E2E tests"
 	MIX_ENV=test E2E=true mix deps.get

--- a/lib/hydra_srt/api/notification.ex
+++ b/lib/hydra_srt/api/notification.ex
@@ -46,7 +46,7 @@ defmodule HydraSrt.Api.Notification do
   end
 
   def validate_config_key(changeset, config, key, label) do
-    value = Map.get(config, key) || Map.get(config, String.to_atom(key))
+    value = HydraSrt.Helpers.get_by_string_key_or(config, key)
 
     if is_binary(value) and String.trim(value) != "" do
       changeset

--- a/lib/hydra_srt/backup.ex
+++ b/lib/hydra_srt/backup.ex
@@ -32,14 +32,21 @@ defmodule HydraSrt.Backup do
   - Validate via `PRAGMA integrity_check`
   - Stop `HydraSrt.Repo`, atomically swap DB file, remove `-wal/-shm`, restart `HydraSrt.Repo`
   """
+  # sobelow_skip ["Traversal.FileModule"]
   def restore_db_file(binary) when is_binary(binary) do
     :global.trans({__MODULE__, :backup_restore}, fn ->
       db_path = repo_database_path()
-      dir = Path.dirname(db_path)
-      tmp_path = Path.join(dir, "hydra_srt_restore_#{System.unique_integer([:positive])}.db")
+      dir = repo_database_dir()
+
+      tmp_path =
+        Path.join(dir, "hydra_srt_restore_#{System.unique_integer([:positive])}.db")
+
       bak_path = db_path <> ".bak"
 
-      with :ok <- File.mkdir_p(dir),
+      with :ok <- ensure_repo_db_path(dir),
+           :ok <- ensure_repo_db_path(tmp_path),
+           :ok <- ensure_repo_db_path(bak_path),
+           :ok <- File.mkdir_p(dir),
            :ok <- File.write(tmp_path, binary),
            :ok <- validate_db_file(tmp_path),
            :ok <- stop_repo(),
@@ -71,6 +78,23 @@ defmodule HydraSrt.Backup do
       other -> raise "HydraSrt.Repo database path is not configured: #{inspect(other)}"
     end
   end
+
+  def repo_database_dir do
+    repo_database_path() |> Path.dirname() |> Path.expand()
+  end
+
+  def ensure_repo_db_path(path) when is_binary(path) do
+    expanded = Path.expand(path)
+    root = repo_database_dir()
+
+    if expanded == root or String.starts_with?(expanded, root <> "/") do
+      :ok
+    else
+      {:error, :invalid_path}
+    end
+  end
+
+  def ensure_repo_db_path(_), do: {:error, :invalid_path}
 
   @doc false
   def validate_db_file(db_path) when is_binary(db_path) do
@@ -130,17 +154,21 @@ defmodule HydraSrt.Backup do
   @doc false
   def swap_db_files(db_path, tmp_path, bak_path)
       when is_binary(db_path) and is_binary(tmp_path) and is_binary(bak_path) do
-    _ = safe_rm(bak_path)
+    with :ok <- ensure_repo_db_path(db_path),
+         :ok <- ensure_repo_db_path(tmp_path),
+         :ok <- ensure_repo_db_path(bak_path) do
+      _ = safe_rm(bak_path)
 
-    case File.exists?(db_path) do
-      true ->
-        case File.rename(db_path, bak_path) do
-          :ok -> do_swap(tmp_path, db_path, bak_path)
-          {:error, reason} -> {:error, reason}
-        end
+      case File.exists?(db_path) do
+        true ->
+          case File.rename(db_path, bak_path) do
+            :ok -> do_swap(tmp_path, db_path, bak_path)
+            {:error, reason} -> {:error, reason}
+          end
 
-      false ->
-        do_swap(tmp_path, db_path, bak_path)
+        false ->
+          do_swap(tmp_path, db_path, bak_path)
+      end
     end
   end
 
@@ -165,11 +193,14 @@ defmodule HydraSrt.Backup do
   end
 
   @doc false
+  # sobelow_skip ["Traversal.FileModule"]
   def safe_rm(path) when is_binary(path) do
-    case File.rm(path) do
-      :ok -> :ok
-      {:error, :enoent} -> :ok
-      other -> other
+    with :ok <- ensure_repo_db_path(path) do
+      case File.rm(path) do
+        :ok -> :ok
+        {:error, :enoent} -> :ok
+        other -> other
+      end
     end
   end
 end

--- a/lib/hydra_srt/db.ex
+++ b/lib/hydra_srt/db.ex
@@ -412,7 +412,7 @@ defmodule HydraSrt.Db do
   end
 
   def notification_param(attrs, key, default) do
-    value = Map.get(attrs, key, Map.get(attrs, String.to_atom(key), default))
+    value = HydraSrt.Helpers.get_by_string_key(attrs, key, default)
 
     case value do
       true -> true
@@ -445,7 +445,7 @@ defmodule HydraSrt.Db do
   end
 
   def notification_param_string(attrs, key) when is_map(attrs) do
-    value = Map.get(attrs, key, Map.get(attrs, String.to_atom(key)))
+    value = HydraSrt.Helpers.get_by_string_key(attrs, key)
 
     case value do
       nil -> nil

--- a/lib/hydra_srt/helpers.ex
+++ b/lib/hydra_srt/helpers.ex
@@ -14,6 +14,43 @@ defmodule HydraSrt.Helpers do
     Process.flag(:max_heap_size, %{size: max_heap_words})
   end
 
+  @spec get_by_string_key(map(), String.t(), term()) :: term()
+  def get_by_string_key(map, key, default \\ nil) when is_map(map) and is_binary(key) do
+    case Map.fetch(map, key) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        case existing_atom_key(map, key) do
+          {:ok, value} -> value
+          :error -> default
+        end
+    end
+  end
+
+  @spec get_by_string_key_or(map(), String.t(), term()) :: term()
+  def get_by_string_key_or(map, key, default \\ nil) when is_map(map) and is_binary(key) do
+    Map.get(map, key) ||
+      case existing_atom_key(map, key) do
+        {:ok, value} -> value
+        :error -> default
+      end
+  end
+
+  @spec has_string_key?(map(), String.t()) :: boolean()
+  def has_string_key?(map, key) when is_map(map) and is_binary(key) do
+    Map.has_key?(map, key) or match?({:ok, _}, existing_atom_key(map, key))
+  end
+
+  @doc false
+  def existing_atom_key(map, key) when is_map(map) and is_binary(key) do
+    try do
+      Map.fetch(map, String.to_existing_atom(key))
+    rescue
+      ArgumentError -> :error
+    end
+  end
+
   def sys_kill(process_id) do
     System.cmd("kill", ["-9", "#{process_id}"])
   end

--- a/lib/hydra_srt/monitoring/net_if.ex
+++ b/lib/hydra_srt/monitoring/net_if.ex
@@ -5,6 +5,7 @@ defmodule HydraSrt.Monitoring.NetIf do
 
   @sysfs_stats_base "/sys/class/net"
   @linux_proc_net_dev "/proc/net/dev"
+  @iface_name_pattern ~r/^[A-Za-z0-9._:@-]+$/
 
   @type iface_counters :: %{optional(atom()) => non_neg_integer()}
   @type snapshot :: %{optional(binary()) => iface_counters()}
@@ -131,29 +132,40 @@ defmodule HydraSrt.Monitoring.NetIf do
     end
   end
 
-  defp read_linux_iface_stats(iface) do
-    stats_dir = Path.join([@sysfs_stats_base, iface, "statistics"])
+  # sobelow_skip ["Traversal.FileModule"]
+  defp read_linux_iface_stats(iface) when is_binary(iface) do
+    if valid_iface_name?(iface) do
+      stats_dir = Path.join([@sysfs_stats_base, iface, "statistics"])
 
-    NetIfMetrics.counter_keys()
-    |> Enum.reduce(%{}, fn key, acc ->
-      path = Path.join(stats_dir, Atom.to_string(key))
+      NetIfMetrics.counter_keys()
+      |> Enum.reduce(%{}, fn key, acc ->
+        path = Path.join(stats_dir, Atom.to_string(key))
 
-      case File.read(path) do
-        {:ok, value} ->
-          case Integer.parse(String.trim(value)) do
-            {parsed, ""} -> Map.put(acc, key, parsed)
-            _ -> acc
-          end
+        case File.read(path) do
+          {:ok, value} ->
+            case Integer.parse(String.trim(value)) do
+              {parsed, ""} -> Map.put(acc, key, parsed)
+              _ -> acc
+            end
 
-        _ ->
-          acc
+          _ ->
+            acc
+        end
+      end)
+      |> case do
+        stats when map_size(stats) == 0 -> nil
+        stats -> stats
       end
-    end)
-    |> case do
-      stats when map_size(stats) == 0 -> nil
-      stats -> stats
+    else
+      nil
     end
   end
+
+  defp valid_iface_name?(iface) when is_binary(iface) do
+    Regex.match?(@iface_name_pattern, iface)
+  end
+
+  defp valid_iface_name?(_), do: false
 
   defp parse_linux_proc_counters(counters) when length(counters) >= 12 do
     with {:ok, rx_bytes} <- parse_int_at(counters, 0),

--- a/lib/hydra_srt/monitoring/net_if_metrics.ex
+++ b/lib/hydra_srt/monitoring/net_if_metrics.ex
@@ -34,6 +34,17 @@ defmodule HydraSrt.Monitoring.NetIfMetrics do
     tx_dropped: "net_tx_dropped_per_sec"
   }
 
+  @rate_counter_keys %{
+    rx_bytes: :rx_bytes_per_sec,
+    tx_bytes: :tx_bytes_per_sec,
+    rx_packets: :rx_packets_per_sec,
+    tx_packets: :tx_packets_per_sec,
+    rx_errors: :rx_errors_per_sec,
+    tx_errors: :tx_errors_per_sec,
+    rx_dropped: :rx_dropped_per_sec,
+    tx_dropped: :tx_dropped_per_sec
+  }
+
   @spec counter_keys() :: [atom()]
   def counter_keys, do: @counter_keys
 
@@ -42,4 +53,12 @@ defmodule HydraSrt.Monitoring.NetIfMetrics do
 
   @spec rate_metric_keys() :: %{atom() => binary()}
   def rate_metric_keys, do: @rate_metric_keys
+
+  @spec rate_counter_keys() :: %{atom() => atom()}
+  def rate_counter_keys, do: @rate_counter_keys
+
+  @spec rate_counter_key(atom()) :: atom()
+  def rate_counter_key(counter_key) when is_atom(counter_key) do
+    Map.fetch!(@rate_counter_keys, counter_key)
+  end
 end

--- a/lib/hydra_srt/monitoring/osmon.ex
+++ b/lib/hydra_srt/monitoring/osmon.ex
@@ -223,7 +223,7 @@ defmodule HydraSrt.PromEx.Plugins.OsMon do
   defp merge_network_rates(counters, rate_values) do
     Enum.reduce(NetIfMetrics.counter_keys(), counters, fn key, acc ->
       value = Map.get(rate_values, key)
-      Map.put(acc, :"#{key}_per_sec", value)
+      Map.put(acc, NetIfMetrics.rate_counter_key(key), value)
     end)
   end
 

--- a/lib/hydra_srt/notifications/telegram.ex
+++ b/lib/hydra_srt/notifications/telegram.ex
@@ -183,7 +183,7 @@ defmodule HydraSrt.Notifications.Telegram do
   end
 
   def config_value(config, key) when is_map(config) do
-    value = Map.get(config, key) || Map.get(config, String.to_atom(key))
+    value = HydraSrt.Helpers.get_by_string_key_or(config, key)
 
     case value do
       nil -> ""

--- a/lib/hydra_srt/source_probe.ex
+++ b/lib/hydra_srt/source_probe.ex
@@ -83,24 +83,22 @@ defmodule HydraSrt.SourceProbe do
         Logger.error("SourceProbe: ffprobe executable not found in PATH")
         {:error, "ffprobe is not available on the server"}
 
-      path ->
-        Logger.debug("SourceProbe: using ffprobe executable path=#{path}")
-        {:ok, path}
+      _path ->
+        Logger.debug("SourceProbe: using ffprobe executable from PATH")
+        {:ok, :ffprobe}
     end
   end
 
-  defp run_ffprobe(ffprobe_path, probe_uri) do
+  defp run_ffprobe(:ffprobe, probe_uri) do
     sanitized_uri = sanitize_uri(probe_uri)
 
     Logger.info("SourceProbe: starting ffprobe uri=#{sanitized_uri}")
 
-    Logger.debug(
-      "SourceProbe: command=#{ffprobe_path} #{Enum.join(ffprobe_args(sanitized_uri), " ")}"
-    )
+    Logger.debug("SourceProbe: command=ffprobe #{Enum.join(ffprobe_args(sanitized_uri), " ")}")
 
     task =
       Task.async(fn ->
-        System.cmd(ffprobe_path, ffprobe_args(probe_uri), stderr_to_stdout: true)
+        System.cmd("ffprobe", ffprobe_args(probe_uri), stderr_to_stdout: true)
       end)
 
     case Task.yield(task, @ffprobe_timeout_ms) || Task.shutdown(task, :brutal_kill) do

--- a/lib/hydra_srt/stats/analytics.ex
+++ b/lib/hydra_srt/stats/analytics.ex
@@ -1331,13 +1331,13 @@ defmodule HydraSrt.Stats.Analytics do
           row.entity_type == "net_if" and row.metric_key == "net_rx_bytes_per_sec" ->
             case net_interface_name(row.entity_id) do
               nil -> current
-              interface_name -> Map.put(current, :"net_in_#{interface_name}", value)
+              interface_name -> Map.put(current, "net_in_#{interface_name}", value)
             end
 
           row.entity_type == "net_if" and row.metric_key == "net_tx_bytes_per_sec" ->
             case net_interface_name(row.entity_id) do
               nil -> current
-              interface_name -> Map.put(current, :"net_out_#{interface_name}", value)
+              interface_name -> Map.put(current, "net_out_#{interface_name}", value)
             end
 
           true ->

--- a/lib/hydra_srt/stats/system_telemetry_collector.ex
+++ b/lib/hydra_srt/stats/system_telemetry_collector.ex
@@ -236,7 +236,9 @@ defmodule HydraSrt.Stats.SystemTelemetryCollector do
 
   defp net_rate_measurement_keys do
     NetIfMetrics.rate_metric_keys()
-    |> Enum.into(%{}, fn {key, metric_key} -> {:"#{key}_per_sec", metric_key} end)
+    |> Enum.into(%{}, fn {counter_key, metric_key} ->
+      {NetIfMetrics.rate_counter_key(counter_key), metric_key}
+    end)
   end
 
   defp normalize_metadata(metadata) when is_map(metadata), do: metadata

--- a/lib/hydra_srt_web/controllers/init_controller.ex
+++ b/lib/hydra_srt_web/controllers/init_controller.ex
@@ -41,8 +41,8 @@ defmodule HydraSrtWeb.InitController do
       nil ->
         "unavailable"
 
-      rustc_path ->
-        case System.cmd(rustc_path, ["--version"], stderr_to_stdout: true) do
+      _rustc_path ->
+        case System.cmd("rustc", ["--version"], stderr_to_stdout: true) do
           {output, 0} -> String.trim(output)
           _ -> "unavailable"
         end

--- a/lib/hydra_srt_web/controllers/notification_controller.ex
+++ b/lib/hydra_srt_web/controllers/notification_controller.ex
@@ -95,7 +95,7 @@ defmodule HydraSrtWeb.NotificationController do
   end
 
   def has_notification_key?(attrs, key) when is_map(attrs) and is_binary(key) do
-    Map.has_key?(attrs, key) or Map.has_key?(attrs, String.to_atom(key))
+    HydraSrt.Helpers.has_string_key?(attrs, key)
   end
 
   def serialize_telegram(nil) do

--- a/lib/hydra_srt_web/controllers/page_controller.ex
+++ b/lib/hydra_srt_web/controllers/page_controller.ex
@@ -1,6 +1,8 @@
 defmodule HydraSrtWeb.PageController do
   use HydraSrtWeb, :controller
 
+  @index_html Application.app_dir(:hydra_srt, "priv/static/index.html")
+
   def index(conn, %{"path" => ["index.html" | _rest]}) do
     conn
     |> redirect(to: "/")
@@ -14,6 +16,6 @@ defmodule HydraSrtWeb.PageController do
   defp serve_index_html(conn) do
     conn
     |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> Plug.Conn.send_file(200, Application.app_dir(:hydra_srt, "priv/static/index.html"))
+    |> Plug.Conn.send_file(200, @index_html)
   end
 end

--- a/lib/hydra_srt_web/endpoint.ex
+++ b/lib/hydra_srt_web/endpoint.ex
@@ -15,6 +15,8 @@ defmodule HydraSrtWeb.Endpoint do
     same_site: "Lax"
   ]
 
+  plug(HydraSrtWeb.Plugs.SecureBrowserHeaders)
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/lib/hydra_srt_web/plugs/secure_browser_headers.ex
+++ b/lib/hydra_srt_web/plugs/secure_browser_headers.ex
@@ -1,0 +1,14 @@
+defmodule HydraSrtWeb.Plugs.SecureBrowserHeaders do
+  @moduledoc false
+
+  import Phoenix.Controller, only: [put_secure_browser_headers: 2]
+
+  @headers %{
+    "content-security-policy" =>
+      "default-src 'self'; connect-src 'self' ws: wss:; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'"
+  }
+
+  def init(opts), do: opts
+
+  def call(conn, _opts), do: put_secure_browser_headers(conn, @headers)
+end

--- a/lib/hydra_srt_web/router.ex
+++ b/lib/hydra_srt_web/router.ex
@@ -3,6 +3,8 @@ defmodule HydraSrtWeb.Router do
 
   pipeline :browser do
     plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:protect_from_forgery)
   end
 
   pipeline :api do

--- a/mix.exs
+++ b/mix.exs
@@ -74,6 +74,7 @@ defmodule HydraSrt.MixProject do
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:credence, "~> 0.5.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
+      {:sobelow, "~> 0.14", only: [:dev, :test], runtime: false, warn_if_outdated: true},
 
       # Benchmarking
       {:benchee, "~> 1.3", only: :dev},
@@ -89,6 +90,18 @@ defmodule HydraSrt.MixProject do
   #     $ mix setup
   #
   # See the documentation for `Mix` for more info on aliases.
+  @sobelow_ignore_files [
+    "config/dev.exs",
+    "config/test.exs",
+    "config/runtime.exs"
+  ]
+
+  defp sobelow_cmd do
+    ignore_files = Enum.join(@sobelow_ignore_files, ",")
+
+    "sobelow --no-config --exit Low --verbose --skip -i Config.HTTPS,Config.Headers --ignore-files #{ignore_files}"
+  end
+
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup"],
@@ -97,11 +110,13 @@ defmodule HydraSrt.MixProject do
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "compile.rs_native": &rs_native_build/1,
       credence: ["credence"],
+      sobelow: [sobelow_cmd()],
       q: ["quality"],
       quality: [
         "format --check-formatted",
         "compile --warnings-as-errors",
         "credo --min-priority higher",
+        "sobelow",
         "dialyzer"
       ]
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -55,6 +55,7 @@
   "ranch": {:hex, :ranch, "2.2.0", "25528f82bc8d7c6152c57666ca99ec716510fe0925cb188172f41ce93117b1b0", [:make, :rebar3], [], "hexpm", "fa0b99a1780c80218a4197a59ea8d3bdae32fbff7e88527d7d8a4787eff4f8e7"},
   "recon": {:hex, :recon, "2.5.6", "9052588e83bfedfd9b72e1034532aee2a5369d9d9343b61aeb7fbce761010741", [:mix, :rebar3], [], "hexpm", "96c6799792d735cc0f0fd0f86267e9d351e63339cbe03df9d162010cefc26bb0"},
   "sleeplocks": {:hex, :sleeplocks, "1.1.3", "96a86460cc33b435c7310dbd27ec82ca2c1f24ae38e34f8edde97f756503441a", [:rebar3], [], "hexpm", "d3b3958552e6eb16f463921e70ae7c767519ef8f5be46d7696cc1ed649421321"},
+  "sobelow": {:hex, :sobelow, "0.14.1", "2f81e8632f15574cba2402bcddff5497b413c01e6f094bc0ab94e83c2f74db81", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8fac9a2bd90fdc4b15d6fca6e1608efb7f7c600fa75800813b794ee9364c87f2"},
   "sourceror": {:hex, :sourceror, "1.12.0", "da354c5f35aad3cc1132f5d5b0d8437d865e2661c263260480bab51b5eedb437", [:mix], [], "hexpm", "755703683bd014ebcd5de9acc24b68fb874a660a568d1d63f8f98cd8a6ef9cd0"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},

--- a/test/hydra_srt/backup_test.exs
+++ b/test/hydra_srt/backup_test.exs
@@ -1,0 +1,43 @@
+defmodule HydraSrt.BackupTest do
+  use ExUnit.Case, async: true
+
+  alias HydraSrt.Backup
+
+  test "ensure_repo_db_path allows paths under the repo database directory" do
+    db_path = Backup.repo_database_path()
+    dir = Backup.repo_database_dir()
+
+    assert :ok = Backup.ensure_repo_db_path(dir)
+    assert :ok = Backup.ensure_repo_db_path(db_path)
+    assert :ok = Backup.ensure_repo_db_path(Path.join(dir, "hydra_srt_restore_1.db"))
+    assert :ok = Backup.ensure_repo_db_path(db_path <> ".bak")
+    assert :ok = Backup.ensure_repo_db_path(db_path <> "-wal")
+    assert :ok = Backup.ensure_repo_db_path(db_path <> "-shm")
+  end
+
+  test "ensure_repo_db_path rejects paths outside the repo database directory" do
+    outside = Path.expand("/hydra_backup_outside_#{System.unique_integer([:positive])}.db")
+
+    assert {:error, :invalid_path} = Backup.ensure_repo_db_path(outside)
+    assert {:error, :invalid_path} = Backup.ensure_repo_db_path("/etc/passwd")
+    assert {:error, :invalid_path} = Backup.ensure_repo_db_path(nil)
+  end
+
+  test "safe_rm refuses to delete files outside the repo database directory" do
+    outside = Path.expand("/hydra_backup_outside_#{System.unique_integer([:positive])}.db")
+
+    assert {:error, :invalid_path} = Backup.safe_rm(outside)
+  end
+
+  test "swap_db_files rejects paths outside the repo database directory" do
+    db_path = Backup.repo_database_path()
+    dir = Backup.repo_database_dir()
+    tmp_path = Path.join(dir, "hydra_srt_restore_#{System.unique_integer([:positive])}.db")
+    bak_path = db_path <> ".bak"
+    outside = Path.expand("/hydra_backup_outside_#{System.unique_integer([:positive])}.db")
+
+    assert {:error, :invalid_path} = Backup.swap_db_files(outside, tmp_path, bak_path)
+    assert {:error, :invalid_path} = Backup.swap_db_files(db_path, outside, bak_path)
+    assert {:error, :invalid_path} = Backup.swap_db_files(db_path, tmp_path, outside)
+  end
+end

--- a/test/hydra_srt/helpers_test.exs
+++ b/test/hydra_srt/helpers_test.exs
@@ -1,0 +1,65 @@
+defmodule HydraSrt.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias HydraSrt.Helpers
+
+  describe "get_by_string_key/3" do
+    test "returns string-key value when present, including nil and false" do
+      map = %{"enabled" => false, "note" => nil, "bot_token" => "token"}
+
+      assert Helpers.get_by_string_key(map, "enabled") == false
+      assert Helpers.get_by_string_key(map, "note") == nil
+      assert Helpers.get_by_string_key(map, "bot_token") == "token"
+    end
+
+    test "falls back to existing atom key when string key is absent" do
+      map = %{bot_token: "secret"}
+
+      assert Helpers.get_by_string_key(map, "bot_token") == "secret"
+    end
+
+    test "returns default when neither key form is present" do
+      assert Helpers.get_by_string_key(%{}, "bot_token", :missing) == :missing
+    end
+  end
+
+  describe "get_by_string_key_or/3" do
+    test "falls back to atom key when string-key value is nil or false" do
+      assert Helpers.get_by_string_key_or(%{"bot_token" => nil, bot_token: "secret"}, "bot_token") ==
+               "secret"
+
+      assert Helpers.get_by_string_key_or(
+               %{"bot_token" => false, bot_token: "secret"},
+               "bot_token"
+             ) ==
+               "secret"
+    end
+
+    test "does not fall back to atom key when string-key value is empty string" do
+      map = %{"bot_token" => "", bot_token: "secret"}
+
+      assert Helpers.get_by_string_key_or(map, "bot_token") == ""
+    end
+
+    test "prefers truthy string-key value over atom key" do
+      map = %{"bot_token" => "primary", bot_token: "secondary"}
+
+      assert Helpers.get_by_string_key_or(map, "bot_token") == "primary"
+    end
+
+    test "uses atom key when string key is absent" do
+      map = %{chat_id: "42"}
+
+      assert Helpers.get_by_string_key_or(map, "chat_id") == "42"
+    end
+  end
+
+  describe "has_string_key?/2" do
+    test "detects string or existing atom keys without creating atoms" do
+      map = %{chat_id: "1"}
+
+      assert Helpers.has_string_key?(map, "chat_id")
+      refute Helpers.has_string_key?(map, "missing_key_#{System.unique_integer()}")
+    end
+  end
+end

--- a/test/hydra_srt/route_control_test.exs
+++ b/test/hydra_srt/route_control_test.exs
@@ -1,5 +1,5 @@
 defmodule HydraSrt.RouteControlTest do
-  use HydraSrt.DataCase, async: true
+  use HydraSrt.DataCase, async: false
 
   alias HydraSrt.DbFixtures
   alias HydraSrt.RouteControl


### PR DESCRIPTION
Integrate Sobelow into CI and mix quality, replace unsafe map key atom conversion with existing-atom helpers, constrain backup restore paths, and apply CSP and CSRF protections across the web stack.