### PR TITLE
test(mcp): add e2e_mcp HTTP protocol test layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,3 +212,46 @@ jobs:
         cp native/target/debug/hydra_srt_pipeline priv/native/build/
     - name: Run E2E Tests
       run: mix test --only e2e
+
+  elixir_e2e_mcp_test:
+    name: Elixir MCP E2E Tests
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+      E2E_MCP: true
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install native dependencies (GStreamer / SRT for compile)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config \
+          libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+          gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+          libsrt-openssl-dev
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+    - name: Cache Rust artifacts
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: native
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: '1.18.4'
+        otp-version: '27.3'
+    - name: Restore dependencies cache
+      uses: actions/cache@v3
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Build Rust Native App
+      run: cd native && cargo build
+    - name: Prepare Native Binary
+      run: |
+        mkdir -p priv/native/build
+        cp native/target/debug/hydra_srt_pipeline priv/native/build/
+    - name: Run MCP E2E Tests
+      run: mix test --only e2e_mcp

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,10 @@ test_rs_native_e2e:
 test_e2e_encrypted:
 	E2E=true mix test --only encrypted
 
+.PHONY: test_e2e_mcp
+test_e2e_mcp:
+	E2E_MCP=true mix test --only e2e_mcp
+
 .PHONY: test_backend
 test_backend:
 	mix test
@@ -190,27 +194,32 @@ test_all:
 .PHONY: test_ci_local
 test_ci_local:
 	@echo "Running CI-equivalent local suite"
-	@echo "1/6 Native unit tests"
+	@echo "1/7 Native unit tests"
 	cd native && cargo test -- --nocapture
-	@echo "2/6 Native E2E tests"
+	@echo "2/7 Native E2E tests"
 	MIX_ENV=test NATIVE_E2E=true mix deps.get
 	MIX_ENV=test NATIVE_E2E=true mix deps.compile
 	MIX_ENV=test NATIVE_E2E=true $(MAKE) test_rs_native_e2e
-	@echo "3/6 JS unit tests"
+	@echo "3/7 JS unit tests"
 	cd web_app && npm ci && npm run test:unit
-	@echo "4/6 JS E2E tests"
+	@echo "4/7 JS E2E tests"
 	MIX_ENV=test mix deps.get
 	MIX_ENV=test mix deps.compile
 	cd native && cargo build
 	cd web_app && npx playwright install --with-deps && npm run test:e2e
-	@echo "5/6 Elixir unit tests"
+	@echo "5/7 Elixir unit tests"
 	MIX_ENV=test mix deps.get
 	MIX_ENV=test mix deps.compile
 	MIX_ENV=test mix compile --warnings-as-errors
 	MIX_ENV=test mix format --check-formatted
 	MIX_ENV=test mix sobelow
 	MIX_ENV=test mix test
-	@echo "6/6 Elixir E2E tests"
+	@echo "6/7 Elixir MCP E2E tests"
+	cd native && cargo build
+	mkdir -p priv/native/build
+	cp native/target/debug/hydra_srt_pipeline priv/native/build/
+	@$(MAKE) test_e2e_mcp
+	@echo "7/7 Elixir E2E tests"
 	MIX_ENV=test E2E=true mix deps.get
 	cd native && cargo build
 	mkdir -p priv/native/build

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,9 @@ import Config
 config :hydra_srt,
   env: config_env(),
   ecto_repos: [HydraSrt.Repo],
-  generators: [timestamp_type: :utc_datetime, binary_id: true]
+  generators: [timestamp_type: :utc_datetime, binary_id: true],
+  # Hermes streamable-http transport uses a 5s GenServer.call timeout on tool requests.
+  mcp_probe_timeout_ms: 3_500
 
 config :adbc, :drivers, [:duckdb]
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,14 +2,24 @@ import Config
 
 test_args = System.argv()
 
-e2e_mode_enabled? =
+cli_only_or_include? = fn tag ->
+  Enum.chunk_every(test_args, 2, 1, :discard)
+  |> Enum.any?(fn
+    ["--only", candidate] -> candidate == tag
+    ["--include", candidate] -> candidate == tag
+    _ -> false
+  end)
+end
+
+e2e_mcp_mode_enabled? =
+  System.get_env("E2E_MCP") == "true" or
+    cli_only_or_include?.("e2e_mcp") or cli_only_or_include?.("mcp_probe")
+
+e2e_route_mode_enabled? =
   System.get_env("E2E") == "true" or
-    Enum.chunk_every(test_args, 2, 1, :discard)
-    |> Enum.any?(fn
-      ["--only", tag] -> String.starts_with?(tag, "e2e")
-      ["--include", tag] -> String.starts_with?(tag, "e2e")
-      _ -> false
-    end)
+    cli_only_or_include?.("e2e") or cli_only_or_include?.("encrypted")
+
+shared_http_e2e_mode? = e2e_route_mode_enabled? or e2e_mcp_mode_enabled?
 
 # Configure your database
 #
@@ -17,7 +27,7 @@ e2e_mode_enabled? =
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
 test_database_path =
-  if e2e_mode_enabled? do
+  if shared_http_e2e_mode? do
     System.get_env("E2E_DATABASE_PATH") ||
       Path.join(System.tmp_dir!(), "hydra_srt_e2e_#{System.unique_integer([:positive])}.db")
   else
@@ -35,14 +45,15 @@ config :hydra_srt, HydraSrt.Repo,
   # Note: `mix test` alias runs `ecto.create` and `ecto.migrate`, so a fresh DB path
   # per run is safe and keeps the suite deterministic.
   database: test_database_path,
-  pool_size: if(e2e_mode_enabled?, do: 2, else: 5),
-  pool: if(e2e_mode_enabled?, do: DBConnection.ConnectionPool, else: Ecto.Adapters.SQL.Sandbox),
-  queue_target: if(e2e_mode_enabled?, do: 5_000, else: 50),
-  queue_interval: if(e2e_mode_enabled?, do: 5_000, else: 1_000),
+  pool_size: if(shared_http_e2e_mode?, do: 2, else: 5),
+  pool:
+    if(shared_http_e2e_mode?, do: DBConnection.ConnectionPool, else: Ecto.Adapters.SQL.Sandbox),
+  queue_target: if(shared_http_e2e_mode?, do: 5_000, else: 50),
+  queue_interval: if(shared_http_e2e_mode?, do: 5_000, else: 1_000),
   journal_mode: :wal,
   # E2E shares one DB across HTTP + Repo; longer busy wait reduces `database is locked`
   # under load (see test_helper E2E max_cases: 1 as well).
-  busy_timeout: if(e2e_mode_enabled?, do: 15_000, else: 2_000)
+  busy_timeout: if(shared_http_e2e_mode?, do: 15_000, else: 2_000)
 
 config :hydra_srt,
   analytics_database_path:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -308,7 +308,7 @@ Creates the `tokens` table with indexes on `name` and `hash`.
 - Curated toolset only — not every REST endpoint has an MCP equivalent (see **Out of scope** above).
 - No MCP resources or prompts yet (tools only).
 - No token expiry (`expires_at`) or `last_used_at` — tokens remain valid until deleted.
-- No Playwright E2E tests for `/settings/tokens` yet; MCP tools and auth are covered by unit tests.
+- No Playwright E2E tests for `/settings/tokens` yet; MCP tools and auth are covered by unit tests and opt-in HTTP E2E tests under `test/e2e_mcp/` (`E2E_MCP=true mix test --only e2e_mcp`).
 
 ---
 

--- a/lib/hydra_srt/application.ex
+++ b/lib/hydra_srt/application.ex
@@ -51,7 +51,7 @@ defmodule HydraSrt.Application do
       #  repos: Application.fetch_env!(:hydra_srt, :ecto_repos), skip: skip_migrations?()},
       {Phoenix.PubSub, name: HydraSrt.PubSub, partitions: runtime_schedulers},
       Hermes.Server.Registry,
-      {HydraSrt.Mcp.Server, transport: :streamable_http},
+      {HydraSrt.Mcp.Server, transport: {:streamable_http, start: true}, request_timeout: 20_000},
       {HydraSrt.Stats.PipelineLogger, %{}},
       {HydraSrt.Notifications.Telegram, %{}},
       HydraSrtWeb.Endpoint

--- a/lib/hydra_srt/mcp/helpers.ex
+++ b/lib/hydra_srt/mcp/helpers.ex
@@ -96,6 +96,23 @@ defmodule HydraSrt.Mcp.Helpers do
   @spec analytics_params(map()) :: map()
   def analytics_params(args) when is_map(args), do: HydraSrt.AnalyticsParams.normalize(args)
 
+  @spec probe_timeout_ms() :: pos_integer()
+  def probe_timeout_ms do
+    Application.get_env(:hydra_srt, :mcp_probe_timeout_ms, 3_500)
+  end
+
+  @spec probe_timeout_seconds() :: pos_integer()
+  def probe_timeout_seconds do
+    probe_timeout_ms()
+    |> div(1_000)
+    |> max(1)
+  end
+
+  @spec probe_description_suffix() :: String.t()
+  def probe_description_suffix do
+    " Active network probe via ffprobe; may block up to #{probe_timeout_seconds()} seconds."
+  end
+
   @spec map_with_error({:error, term()}, (term() -> Response.t())) :: {:ok, Response.t()}
   def map_with_error({:error, %{type: :tool} = response}, _handler), do: {:ok, response}
 

--- a/lib/hydra_srt/mcp/input_schema.ex
+++ b/lib/hydra_srt/mcp/input_schema.ex
@@ -1,0 +1,45 @@
+defmodule HydraSrt.Mcp.InputSchema do
+  @moduledoc false
+
+  @spec to_hermes(map()) :: map()
+  def to_hermes(%{"type" => "object", "properties" => properties} = schema)
+      when is_map(properties) do
+    required = Map.get(schema, "required", [])
+
+    Map.new(properties, fn {key, property} ->
+      {key, to_hermes_field(property, key in required)}
+    end)
+  end
+
+  def to_hermes(_schema), do: %{}
+
+  @spec to_hermes_field(map() | term(), boolean()) :: term()
+  def to_hermes_field(property, required?) when is_map(property) do
+    type =
+      case property do
+        %{"type" => "string", "enum" => values} when is_list(values) ->
+          {:enum, values, [type: :string]}
+
+        %{"type" => "integer"} ->
+          :integer
+
+        %{"type" => "array", "items" => %{"type" => "string"}} ->
+          {:list, :string}
+
+        %{"type" => "object"} = nested ->
+          case to_hermes(nested) do
+            nested_fields when map_size(nested_fields) == 0 -> :any
+            nested_fields -> {:object, nested_fields}
+          end
+
+        _ ->
+          :any
+      end
+
+    if required?, do: {:required, type}, else: type
+  end
+
+  def to_hermes_field(_property, required?) do
+    if required?, do: {:required, :any}, else: :any
+  end
+end

--- a/lib/hydra_srt/mcp/tool_registry.ex
+++ b/lib/hydra_srt/mcp/tool_registry.ex
@@ -2,6 +2,7 @@ defmodule HydraSrt.Mcp.ToolRegistry do
   @moduledoc false
 
   alias HydraSrt.Mcp.Helpers
+  alias HydraSrt.Mcp.InputSchema
   alias HydraSrt.Mcp.Tools.Destinations
   alias HydraSrt.Mcp.Tools.Interfaces
   alias HydraSrt.Mcp.Tools.Logs
@@ -40,7 +41,7 @@ defmodule HydraSrt.Mcp.ToolRegistry do
     Enum.reduce(definitions(), frame, fn definition, acc_frame ->
       Hermes.Server.Frame.register_tool(acc_frame, definition.name,
         description: definition.description,
-        input_schema: definition.input_schema
+        input_schema: InputSchema.to_hermes(definition.input_schema)
       )
     end)
   end

--- a/lib/hydra_srt/mcp/tools/routes.ex
+++ b/lib/hydra_srt/mcp/tools/routes.ex
@@ -4,8 +4,6 @@ defmodule HydraSrt.Mcp.Tools.Routes do
   alias HydraSrt.Mcp.Helpers
   alias HydraSrt.Routes
 
-  @probe_description_suffix " Active network probe via ffprobe; may block up to 15 seconds."
-
   @spec definitions() :: [map()]
   def definitions do
     [
@@ -77,7 +75,7 @@ defmodule HydraSrt.Mcp.Tools.Routes do
       %{
         name: "test_route_source",
         description:
-          "Test a route source configuration with ffprobe." <> @probe_description_suffix,
+          "Test a route source configuration with ffprobe." <> Helpers.probe_description_suffix(),
         input_schema:
           object_schema(%{"route" => object_prop("Route/source attributes")}, ["route"])
       }
@@ -165,7 +163,8 @@ defmodule HydraSrt.Mcp.Tools.Routes do
 
   def call("test_route_source", args) do
     with {:ok, route} <- map_param(args, "route"),
-         result <- Routes.test_source_config(route) do
+         result <-
+           Routes.test_source_config(route, timeout_ms: Helpers.probe_timeout_ms()) do
       {:ok, Helpers.from_result(result)}
     end
   end

--- a/lib/hydra_srt/mcp/tools/sources.ex
+++ b/lib/hydra_srt/mcp/tools/sources.ex
@@ -5,8 +5,6 @@ defmodule HydraSrt.Mcp.Tools.Sources do
   alias HydraSrt.Mcp.Tools.Routes, as: Schema
   alias HydraSrt.Sources
 
-  @probe_suffix " Active network probe via ffprobe; may block up to 15 seconds."
-
   @spec definitions() :: [map()]
   def definitions do
     route_id = Schema.string_prop("Route ID")
@@ -71,7 +69,7 @@ defmodule HydraSrt.Mcp.Tools.Sources do
       },
       %{
         name: "test_source",
-        description: "Test a saved source with ffprobe." <> @probe_suffix,
+        description: "Test a saved source with ffprobe." <> Helpers.probe_description_suffix(),
         input_schema:
           Schema.object_schema(
             %{"route_id" => route_id, "source_id" => Schema.string_prop("Source ID")},
@@ -142,7 +140,8 @@ defmodule HydraSrt.Mcp.Tools.Sources do
   def call("test_source", args) do
     with {:ok, route_id} <- Schema.param(args, "route_id"),
          {:ok, source_id} <- Schema.param(args, "source_id"),
-         result <- Sources.test(route_id, source_id) do
+         result <-
+           Sources.test(route_id, source_id, timeout_ms: Helpers.probe_timeout_ms()) do
       {:ok, Helpers.from_result(result)}
     end
   end

--- a/lib/hydra_srt/routes.ex
+++ b/lib/hydra_srt/routes.ex
@@ -67,9 +67,9 @@ defmodule HydraSrt.Routes do
     RouteControl.switch_route_source(route_id, source_id)
   end
 
-  @spec test_source_config(map()) :: {:ok, map()} | {:error, String.t()}
-  def test_source_config(route_params) when is_map(route_params) do
-    case SourceProbe.probe(route_params) do
+  @spec test_source_config(map(), keyword()) :: {:ok, map()} | {:error, String.t()}
+  def test_source_config(route_params, opts \\ []) when is_map(route_params) do
+    case SourceProbe.probe(route_params, opts) do
       {:ok, result} -> {:ok, result}
       {:error, reason} -> {:error, SourceProbe.client_error(reason)}
     end

--- a/lib/hydra_srt/source_probe.ex
+++ b/lib/hydra_srt/source_probe.ex
@@ -5,14 +5,18 @@ defmodule HydraSrt.SourceProbe do
 
   alias HydraSrt.RouteHandler
 
-  @ffprobe_timeout_ms 15_000
+  @default_ffprobe_timeout_ms 15_000
   @passphrase_mask "[REDACTED]"
 
-  @spec probe(map()) :: {:ok, map()} | {:error, atom() | binary()}
-  def probe(route_params) when is_map(route_params) do
+  @spec probe(map(), keyword()) :: {:ok, map()} | {:error, atom() | binary()}
+  def probe(route_params, opts \\ [])
+
+  def probe(route_params, opts) when is_map(route_params) do
+    timeout_ms = Keyword.get(opts, :timeout_ms, @default_ffprobe_timeout_ms)
+
     with {:ok, probe_uri} <- build_probe_uri(route_params),
          {:ok, ffprobe_path} <- find_ffprobe(),
-         {:ok, raw_output} <- run_ffprobe(ffprobe_path, probe_uri),
+         {:ok, raw_output} <- run_ffprobe(ffprobe_path, probe_uri, timeout_ms),
          {:ok, parsed_output} <- decode_output(raw_output) do
       Logger.info("SourceProbe: ffprobe succeeded uri=#{sanitize_uri(probe_uri)}")
 
@@ -26,7 +30,7 @@ defmodule HydraSrt.SourceProbe do
     end
   end
 
-  def probe(_), do: {:error, :invalid_source}
+  def probe(_route_params, _opts), do: {:error, :invalid_source}
 
   @spec client_error(term()) :: String.t()
   def client_error(reason) do
@@ -89,7 +93,8 @@ defmodule HydraSrt.SourceProbe do
     end
   end
 
-  defp run_ffprobe(:ffprobe, probe_uri) do
+  def run_ffprobe(:ffprobe, probe_uri, timeout_ms)
+      when is_integer(timeout_ms) and timeout_ms > 0 do
     sanitized_uri = sanitize_uri(probe_uri)
 
     Logger.info("SourceProbe: starting ffprobe uri=#{sanitized_uri}")
@@ -101,7 +106,7 @@ defmodule HydraSrt.SourceProbe do
         System.cmd("ffprobe", ffprobe_args(probe_uri), stderr_to_stdout: true)
       end)
 
-    case Task.yield(task, @ffprobe_timeout_ms) || Task.shutdown(task, :brutal_kill) do
+    case Task.yield(task, timeout_ms) || Task.shutdown(task, :brutal_kill) do
       {:ok, {output, 0}} ->
         Logger.debug("SourceProbe: ffprobe completed successfully uri=#{sanitized_uri}")
         {:ok, output}
@@ -120,10 +125,10 @@ defmodule HydraSrt.SourceProbe do
 
       _ ->
         Logger.warning(
-          "SourceProbe: ffprobe timed out uri=#{sanitized_uri} timeout_ms=#{@ffprobe_timeout_ms}"
+          "SourceProbe: ffprobe timed out uri=#{sanitized_uri} timeout_ms=#{timeout_ms}"
         )
 
-        {:error, "ffprobe timed out after #{@ffprobe_timeout_ms}ms"}
+        {:error, "ffprobe timed out after #{timeout_ms}ms"}
     end
   end
 

--- a/lib/hydra_srt/sources.ex
+++ b/lib/hydra_srt/sources.ex
@@ -33,10 +33,11 @@ defmodule HydraSrt.Sources do
       when is_binary(route_id) and is_list(source_ids),
       do: Db.reorder_sources(route_id, source_ids)
 
-  @spec test(String.t(), String.t()) :: {:ok, map()} | {:error, term()}
-  def test(route_id, source_id) when is_binary(route_id) and is_binary(source_id) do
+  @spec test(String.t(), String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def test(route_id, source_id, opts \\ [])
+      when is_binary(route_id) and is_binary(source_id) do
     with {:ok, source} <- Db.get_source(route_id, source_id) do
-      Routes.test_source_config(source)
+      Routes.test_source_config(source, opts)
     end
   end
 end

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -15,6 +15,7 @@ Stable, reusable patterns for unit, integration, and E2E tests across Elixir, th
 |-------|---------|----------|--------|
 | Elixir unit | `mix test` | `make test_backend` | `elixir_test` |
 | Elixir E2E | `E2E=true mix test --only e2e` | `make test_e2e` | `elixir_e2e_test` |
+| Elixir MCP E2E | `E2E_MCP=true mix test --only e2e_mcp` | `make test_e2e_mcp` | `elixir_e2e_mcp_test` |
 | Elixir E2E encrypted | `E2E=true mix test --only encrypted` | `make test_e2e_encrypted` | — |
 | Native unit (Rust) | `cd native && cargo test` | `make test_rs_native_unit` | `rs_native_unit_test` |
 | Native E2E | `NATIVE_E2E=true mix test test/native_e2e` | `make test_rs_native_e2e` | `rs_native_e2e_test` |
@@ -27,6 +28,7 @@ Stable, reusable patterns for unit, integration, and E2E tests across Elixir, th
 
 - **Elixir unit** — `mix deps.get`, native binary built for compile (`mix compile` triggers `compile.rs_native`).
 - **Elixir E2E** — `ffmpeg`, `srt-tools` (or `srt-live-transmit`) in PATH; native pipeline binary; see `HydraSrt.TestSupport.E2EHelpers`.
+- **Elixir MCP E2E** — native pipeline binary and HTTP endpoint only (no ffmpeg/SRT streaming tools); see `HydraSrt.TestSupport.McpE2EClient` and `test/e2e_mcp/`.
 - **Elixir E2E encrypted** — ffmpeg/libsrt build with SRT passphrase support; otherwise `:encrypted` tests are auto-excluded.
 - **Native unit/E2E** — GStreamer and SRT dev libraries (see CI workflow `apt-get` steps).
 - **Web unit** — `cd web_app && npm ci`.
@@ -38,6 +40,9 @@ Stable, reusable patterns for unit, integration, and E2E tests across Elixir, th
 mix test test/hydra_srt/route_handler_test.exs
 mix test test/hydra_srt/route_handler_test.exs:42
 E2E=true mix test test/e2e/srt_pipeline_e2e_test.exs
+E2E_MCP=true mix test --only e2e_mcp
+E2E_MCP=true mix test --only e2e_mcp --include mcp_probe
+mix test test/e2e_mcp/auth_test.exs
 mix test test/hydra_srt/db_tokens_test.exs test/hydra_srt_web/controllers/token_controller_test.exs
 cd web_app && npm run test:unit:watch
 TRACE=true mix test
@@ -55,6 +60,11 @@ E2E_DEBUG_LOGS=true E2E=true mix test --only e2e
 | `HydraSrt.DataCase` | Ecto tests with SQL Sandbox |
 | `HydraSrtWeb.ConnCase` | Phoenix `ConnTest` + sandbox |
 | `HydraSrt.TestSupport.E2EHelpers` | E2E prereqs: app/endpoint start, ffmpeg/SRT probes, CI-aware timeouts, pipeline cleanup |
+| `HydraSrt.TestSupport.McpE2ECase` | MCP E2E ExUnit template (`test/e2e_mcp/`): Hermes client, fixtures, assertions |
+| `HydraSrt.TestSupport.McpE2EProbeCase` | ffprobe probe MCP E2E template (`:mcp_probe` only; opt-in via `--include mcp_probe`) |
+| `HydraSrt.TestSupport.McpE2EClient` | Hermes `Client` over Streamable HTTP for `/mcp` |
+| `HydraSrt.TestSupport.McpE2EFixtures` | Seeded route/source/destination/tag/interface context for tool calls |
+| `HydraSrt.TestSupport.McpE2EAssertions` | Auth rejection and MCP tool response assertions |
 | `HydraSrt.ApiFixtures` | API-level test data (`test/support/fixtures/api_fixtures.ex`) |
 | `HydraSrt.DbFixtures` | DB fixtures (`test/support/fixtures/db_fixtures.ex`) |
 
@@ -76,14 +86,17 @@ Configured in `test/test_helper.exs`:
 | Tag / mode | Default | Enable |
 |------------|---------|--------|
 | `:e2e` | excluded | `E2E=true` or `mix test --only e2e` |
+| `:e2e_mcp` | excluded | `E2E_MCP=true` or `mix test --only e2e_mcp` |
+| `:mcp_probe` | excluded | `E2E_MCP=true mix test --only e2e_mcp --include mcp_probe` (ffprobe probes; ~30s extra) |
 | `:native_e2e` | excluded | `NATIVE_E2E=true` |
 | `:encrypted` | excluded if ffmpeg lacks SRT encryption | `E2E=true mix test --only encrypted` |
 
-**E2E mode behaviour:**
+**E2E mode behaviour (route and MCP):**
 
 - `ExUnit.configure(max_cases: 1)` — shared SQLite + HTTP endpoint; no parallel E2E.
-- `HydraSrt.TestSupport.E2EHelpers.ensure_e2e_prereqs!()` runs before the suite.
-- `ExUnit.after_suite/1` kills leftover pipelines.
+- Route E2E: `HydraSrt.TestSupport.E2EHelpers.ensure_e2e_prereqs!()` (ffmpeg, native, pipeline cleanup).
+- MCP E2E: `HydraSrt.TestSupport.E2EHelpers.ensure_e2e_mcp_prereqs!()` (lighter; no ffmpeg/SRT streaming tools).
+- `ExUnit.after_suite/1` kills leftover pipelines after route E2E.
 
 **Unit mode:** SQL Sandbox in manual mode when Repo is running.
 
@@ -108,7 +121,7 @@ Configured in `test/test_helper.exs`:
 
 - `HydraSrt.RouteHandler` — route lifecycle, failover
 - `HydraSrtWeb` controllers and `RealtimeChannel`
-- MCP tokens and `/mcp` auth — `test/hydra_srt/db_tokens_test.exs`, `test/hydra_srt_web/controllers/token_controller_test.exs`; see [../docs/mcp.md](../docs/mcp.md)
+- MCP tokens and `/mcp` auth — `test/hydra_srt/db_tokens_test.exs`, `test/hydra_srt_web/controllers/token_controller_test.exs`, `test/e2e_mcp/` (HTTP protocol E2E); see [../docs/mcp.md](../docs/mcp.md)
 - E2E SRT/UDP pipelines under `test/e2e/`
 - Native pipeline under `test/native_e2e/`
 - Stats/analytics collectors

--- a/test/e2e_mcp/auth_test.exs
+++ b/test/e2e_mcp/auth_test.exs
@@ -1,0 +1,49 @@
+defmodule HydraSrt.E2E.Mcp.AuthTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  @moduletag :skip_mcp_client
+  @moduletag :skip_mcp_fixtures
+
+  alias HydraSrt.Auth
+  alias HydraSrt.Db
+  alias HydraSrt.TestSupport.McpE2EAssertions, as: McpAssertions
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "rejects requests without bearer token" do
+    McpAssertions.assert_mcp_auth_rejected!()
+  end
+
+  test "rejects requests with invalid bearer token" do
+    McpAssertions.assert_mcp_auth_rejected!(headers: [{"authorization", "Bearer invalid-token"}])
+  end
+
+  test "rejects login session token on mcp endpoint" do
+    session_token = "test_session_#{System.unique_integer([:positive])}"
+    {:ok, _session} = Auth.create_session(session_token, "user_session_data")
+
+    McpAssertions.assert_mcp_auth_rejected!(
+      headers: [{"authorization", "Bearer " <> session_token}]
+    )
+  end
+
+  test "accepts valid bearer token and reaches MCP transport" do
+    {:ok, _token, raw_token} =
+      Db.create_token(%{"name" => "mcp-e2e-auth-#{System.unique_integer([:positive])}"})
+
+    {:ok, status, _headers, body} =
+      HydraSrt.TestSupport.E2EHelpers.http_raw(
+        :post,
+        McpE2EClient.mcp_url(),
+        [
+          {"authorization", "Bearer " <> raw_token},
+          {"accept", McpE2EClient.mcp_accept_header()},
+          {"content-type", "application/json"}
+        ],
+        "{}"
+      )
+
+    assert status == 400
+    assert body =~ "jsonrpc"
+    refute body =~ "Authorization header missing"
+  end
+end

--- a/test/e2e_mcp/destinations_tools_test.exs
+++ b/test/e2e_mcp/destinations_tools_test.exs
@@ -1,0 +1,85 @@
+defmodule HydraSrt.E2E.Mcp.DestinationsToolsTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "list_destinations", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "list_destinations", %{"route_id" => ctx.route_id})
+      )
+
+    assert is_list(structured["data"])
+    assert Enum.any?(structured["data"], &(&1["id"] == ctx.destination_id))
+  end
+
+  test "get_destination", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_destination", %{
+          "route_id" => ctx.route_id,
+          "destination_id" => ctx.destination_id
+        })
+      )
+
+    assert structured["data"]["id"] == ctx.destination_id
+  end
+
+  test "create_destination", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "create_destination", %{
+          "route_id" => ctx.route_id,
+          "destination" => %{
+            "name" => "mcp-e2e-created-destination-#{ctx.suffix}",
+            "schema" => "UDP",
+            "host" => "127.0.0.1",
+            "port" => 32_000 + rem(System.unique_integer([:positive]), 20_000),
+            "enabled" => true
+          }
+        })
+      )
+
+    assert structured["data"]["name"] == "mcp-e2e-created-destination-#{ctx.suffix}"
+  end
+
+  test "update_destination", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "update_destination", %{
+          "route_id" => ctx.route_id,
+          "destination_id" => ctx.destination_id,
+          "destination" => %{"name" => "mcp-e2e-updated-destination-#{ctx.suffix}"}
+        })
+      )
+
+    assert structured["data"]["name"] == "mcp-e2e-updated-destination-#{ctx.suffix}"
+  end
+
+  test "delete_destination", %{client: client, ctx: ctx} do
+    {:ok, created} =
+      McpE2EClient.call_tool(client, "create_destination", %{
+        "route_id" => ctx.route_id,
+        "destination" => %{
+          "name" => "mcp-e2e-delete-destination-#{ctx.suffix}",
+          "schema" => "UDP",
+          "host" => "127.0.0.1",
+          "port" => 42_000 + rem(System.unique_integer([:positive]), 20_000),
+          "enabled" => true
+        }
+      })
+
+    destination_id = McpAssertions.assert_tool_success({:ok, created})["data"]["id"]
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "delete_destination", %{
+          "route_id" => ctx.route_id,
+          "destination_id" => destination_id
+        })
+      )
+
+    assert structured["data"]["deleted"] == true
+    assert structured["data"]["destination_id"] == destination_id
+  end
+end

--- a/test/e2e_mcp/interfaces_tools_test.exs
+++ b/test/e2e_mcp/interfaces_tools_test.exs
@@ -1,0 +1,104 @@
+defmodule HydraSrt.E2E.Mcp.InterfacesToolsTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "list_interfaces", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(McpE2EClient.call_tool(client, "list_interfaces", %{}))
+
+    assert is_list(structured["data"])
+    assert Enum.any?(structured["data"], &(&1["id"] == ctx.interface_id))
+  end
+
+  test "get_interface", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_interface", %{"interface_id" => ctx.interface_id})
+      )
+
+    assert structured["data"]["id"] == ctx.interface_id
+  end
+
+  test "create_interface", %{client: client, ctx: ctx} do
+    name = McpFixtures.disposable_interface_name(ctx)
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "create_interface", %{
+          "interface" => %{
+            "name" => name,
+            "sys_name" => "mcp-e2e-sys-#{ctx.suffix}",
+            "ip" => "127.0.0.2",
+            "enabled" => true
+          }
+        })
+      )
+
+    assert structured["data"]["name"] == name
+  end
+
+  test "update_interface", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "update_interface", %{
+          "interface_id" => ctx.interface_id,
+          "interface" => %{"name" => "mcp-e2e-updated-interface-#{ctx.suffix}"}
+        })
+      )
+
+    assert structured["data"]["name"] == "mcp-e2e-updated-interface-#{ctx.suffix}"
+  end
+
+  test "delete_interface", %{client: client, ctx: ctx} do
+    {:ok, created} =
+      McpE2EClient.call_tool(client, "create_interface", %{
+        "interface" => %{
+          "name" => McpFixtures.disposable_interface_name(ctx),
+          "sys_name" => "mcp-e2e-delete-sys-#{ctx.suffix}",
+          "ip" => "127.0.0.3",
+          "enabled" => true
+        }
+      })
+
+    interface_id = McpAssertions.assert_tool_success({:ok, created})["data"]["id"]
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "delete_interface", %{"interface_id" => interface_id})
+      )
+
+    assert structured["data"]["deleted"] == true
+    assert structured["data"]["interface_id"] == interface_id
+  end
+
+  test "list_system_interfaces", %{client: client} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "list_system_interfaces", %{})
+      )
+
+    assert is_list(structured["data"])
+  end
+
+  test "get_system_interface", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_system_interface", %{
+          "sys_name" => ctx.loopback_sys_name
+        })
+      )
+
+    assert structured["data"]["sys_name"] == ctx.loopback_sys_name
+  end
+
+  test "get_system_interfaces_raw", %{client: client} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_system_interfaces_raw", %{})
+      )
+
+    assert is_binary(structured["data"]["raw"])
+    assert structured["data"]["raw"] != ""
+  end
+end

--- a/test/e2e_mcp/logs_tools_test.exs
+++ b/test/e2e_mcp/logs_tools_test.exs
@@ -1,0 +1,79 @@
+defmodule HydraSrt.E2E.Mcp.LogsToolsTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "get_route_events", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_route_events", %{
+          "route_id" => ctx.route_id,
+          "window" => "last_hour"
+        })
+      )
+
+    assert is_list(structured["data"]["events"])
+    assert is_map(structured["data"]["meta"])
+  end
+
+  test "get_route_pipeline_logs", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_route_pipeline_logs", %{
+          "route_id" => ctx.route_id,
+          "window" => "last_hour"
+        })
+      )
+
+    assert is_list(structured["data"]["logs"])
+    assert is_map(structured["data"]["meta"])
+  end
+
+  test "get_route_pipeline_log_distinct", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_route_pipeline_log_distinct", %{
+          "route_id" => ctx.route_id,
+          "column" => "level"
+        })
+      )
+
+    assert is_list(structured["data"])
+  end
+
+  test "get_routes_status_history", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_routes_status_history", %{
+          "window" => "last_hour",
+          "route_id" => ctx.route_id
+        })
+      )
+
+    assert is_list(structured["data"]["events"])
+    assert is_map(structured["data"]["meta"])
+  end
+
+  test "get_route_analytics", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_route_analytics", %{
+          "route_id" => ctx.route_id,
+          "window" => "last_hour"
+        })
+      )
+
+    assert structured["data"]["meta"]["window"] == "last_hour"
+    assert is_list(structured["data"]["points"])
+  end
+
+  test "get_routes_status_analytics", %{client: client} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_routes_status_analytics", %{"window" => "last_hour"})
+      )
+
+    assert structured["data"]["meta"]["window"] == "last_hour"
+    assert is_list(structured["data"]["points"])
+  end
+end

--- a/test/e2e_mcp/nodes_tools_test.exs
+++ b/test/e2e_mcp/nodes_tools_test.exs
@@ -1,0 +1,34 @@
+defmodule HydraSrt.E2E.Mcp.NodesToolsTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "list_nodes", %{client: client} do
+    structured =
+      McpAssertions.assert_tool_success(McpE2EClient.call_tool(client, "list_nodes", %{}))
+
+    assert is_list(structured["data"])
+    assert structured["data"] != []
+  end
+
+  test "get_self_node", %{client: client} do
+    structured =
+      McpAssertions.assert_tool_success(McpE2EClient.call_tool(client, "get_self_node", %{}))
+
+    assert is_map(structured["data"])
+    assert Map.has_key?(structured["data"], "host")
+  end
+
+  test "get_node_analytics", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_node_analytics", %{
+          "node_id" => ctx.node_id,
+          "window" => "last_hour"
+        })
+      )
+
+    assert structured["data"]["meta"]["window"] == "last_hour"
+    assert is_list(structured["data"]["points"])
+  end
+end

--- a/test/e2e_mcp/probes_tools_test.exs
+++ b/test/e2e_mcp/probes_tools_test.exs
@@ -1,0 +1,61 @@
+defmodule HydraSrt.E2E.Mcp.ProbesToolsTest do
+  use HydraSrt.TestSupport.McpE2EProbeCase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  @probe_timeout 20_000
+
+  test "test_route_source returns structured MCP response for unreachable UDP source", %{
+    client: client,
+    ctx: ctx
+  } do
+    port = 52_000 + rem(System.unique_integer([:positive]), 10_000)
+
+    McpAssertions.assert_tool_responds(
+      McpE2EClient.call_tool(
+        client,
+        "test_route_source",
+        %{
+          "route" => %{
+            "name" => "mcp-e2e-probe-route-#{ctx.suffix}",
+            "source" => %{
+              "schema" => "UDP",
+              "host" => "127.0.0.1",
+              "port" => port
+            }
+          }
+        },
+        timeout: @probe_timeout
+      )
+    )
+  end
+
+  test "test_source returns structured MCP response for unreachable saved source", %{
+    client: client,
+    ctx: ctx
+  } do
+    {:ok, created} =
+      McpE2EClient.call_tool(client, "create_source", %{
+        "route_id" => ctx.route_id,
+        "source" => %{
+          "name" => "mcp-e2e-probe-source-#{ctx.suffix}",
+          "schema" => "UDP",
+          "host" => "127.0.0.1",
+          "port" => 62_000 + rem(System.unique_integer([:positive]), 10_000),
+          "enabled" => true,
+          "position" => 4
+        }
+      })
+
+    source_id = McpAssertions.assert_tool_success({:ok, created})["data"]["id"]
+
+    McpAssertions.assert_tool_responds(
+      McpE2EClient.call_tool(
+        client,
+        "test_source",
+        %{"route_id" => ctx.route_id, "source_id" => source_id},
+        timeout: @probe_timeout
+      )
+    )
+  end
+end

--- a/test/e2e_mcp/protocol_test.exs
+++ b/test/e2e_mcp/protocol_test.exs
@@ -1,0 +1,20 @@
+defmodule HydraSrt.E2E.Mcp.ProtocolTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.Mcp.ToolRegistry
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "ping returns pong", %{client: client} do
+    assert :pong = McpE2EClient.ping(client, timeout: 5_000)
+  end
+
+  test "list_tools returns all curated tools", %{client: client} do
+    assert {:ok, response} = McpE2EClient.list_tools(client, timeout: 10_000)
+
+    result = Hermes.MCP.Response.unwrap(response)
+    tool_names = result["tools"] |> Enum.map(& &1["name"]) |> Enum.sort()
+
+    assert tool_names == ToolRegistry.tool_names()
+    assert length(tool_names) == 43
+  end
+end

--- a/test/e2e_mcp/routes_tools_test.exs
+++ b/test/e2e_mcp/routes_tools_test.exs
@@ -1,0 +1,95 @@
+defmodule HydraSrt.E2E.Mcp.RoutesToolsTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "list_routes", %{client: client} do
+    McpAssertions.assert_tool_success(McpE2EClient.call_tool(client, "list_routes", %{}))
+  end
+
+  test "create_route", %{client: client, ctx: ctx} do
+    name = McpFixtures.disposable_route_name(ctx)
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "create_route", %{
+          "route" => %{"name" => name, "alias" => "mcp e2e", "enabled" => false}
+        })
+      )
+
+    assert structured["data"]["name"] == name
+  end
+
+  test "get_route", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_route", %{"route_id" => ctx.route_id})
+      )
+
+    assert structured["data"]["id"] == ctx.route_id
+  end
+
+  test "update_route", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "update_route", %{
+          "route_id" => ctx.route_id,
+          "route" => %{"name" => "mcp-e2e-updated-#{ctx.suffix}", "enabled" => false}
+        })
+      )
+
+    assert structured["data"]["name"] == "mcp-e2e-updated-#{ctx.suffix}"
+  end
+
+  test "start_route returns structured MCP response", %{client: client, ctx: ctx} do
+    McpAssertions.assert_tool_responds(
+      McpE2EClient.call_tool(client, "start_route", %{"route_id" => ctx.route_id},
+        timeout: 30_000
+      )
+    )
+  end
+
+  test "stop_route returns structured MCP response", %{client: client, ctx: ctx} do
+    McpAssertions.assert_tool_responds(
+      McpE2EClient.call_tool(client, "stop_route", %{"route_id" => ctx.route_id}, timeout: 30_000)
+    )
+  end
+
+  test "restart_route returns structured MCP response", %{client: client, ctx: ctx} do
+    McpAssertions.assert_tool_responds(
+      McpE2EClient.call_tool(client, "restart_route", %{"route_id" => ctx.route_id},
+        timeout: 30_000
+      )
+    )
+  end
+
+  test "switch_route_source returns structured MCP response", %{client: client, ctx: ctx} do
+    McpAssertions.assert_tool_responds(
+      McpE2EClient.call_tool(client, "switch_route_source", %{
+        "route_id" => ctx.route_id,
+        "source_id" => ctx.source2_id
+      })
+    )
+  end
+
+  test "delete_route", %{client: client, ctx: ctx} do
+    {:ok, created} =
+      McpE2EClient.call_tool(client, "create_route", %{
+        "route" => %{
+          "name" => McpFixtures.disposable_route_name(ctx),
+          "alias" => "delete me",
+          "enabled" => false
+        }
+      })
+
+    route_id = McpAssertions.assert_tool_success({:ok, created})["data"]["id"]
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "delete_route", %{"route_id" => route_id})
+      )
+
+    assert structured["data"]["deleted"] == true
+    assert structured["data"]["route_id"] == route_id
+  end
+end

--- a/test/e2e_mcp/sources_tools_test.exs
+++ b/test/e2e_mcp/sources_tools_test.exs
@@ -1,0 +1,99 @@
+defmodule HydraSrt.E2E.Mcp.SourcesToolsTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "list_sources", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "list_sources", %{"route_id" => ctx.route_id})
+      )
+
+    assert is_list(structured["data"])
+    assert Enum.any?(structured["data"], &(&1["id"] == ctx.source_id))
+  end
+
+  test "get_source", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "get_source", %{
+          "route_id" => ctx.route_id,
+          "source_id" => ctx.source_id
+        })
+      )
+
+    assert structured["data"]["id"] == ctx.source_id
+  end
+
+  test "create_source", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "create_source", %{
+          "route_id" => ctx.route_id,
+          "source" => %{
+            "name" => "mcp-e2e-created-source-#{ctx.suffix}",
+            "schema" => "UDP",
+            "host" => "127.0.0.1",
+            "port" => 12_000 + rem(System.unique_integer([:positive]), 20_000),
+            "enabled" => true,
+            "position" => 2
+          }
+        })
+      )
+
+    assert structured["data"]["name"] == "mcp-e2e-created-source-#{ctx.suffix}"
+  end
+
+  test "update_source", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "update_source", %{
+          "route_id" => ctx.route_id,
+          "source_id" => ctx.source_id,
+          "source" => %{"name" => "mcp-e2e-updated-source-#{ctx.suffix}"}
+        })
+      )
+
+    assert structured["data"]["name"] == "mcp-e2e-updated-source-#{ctx.suffix}"
+  end
+
+  test "reorder_sources", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "reorder_sources", %{
+          "route_id" => ctx.route_id,
+          "source_ids" => [ctx.source2_id, ctx.source_id]
+        })
+      )
+
+    assert is_list(structured["data"])
+  end
+
+  test "delete_source", %{client: client, ctx: ctx} do
+    {:ok, created} =
+      McpE2EClient.call_tool(client, "create_source", %{
+        "route_id" => ctx.route_id,
+        "source" => %{
+          "name" => "mcp-e2e-delete-source-#{ctx.suffix}",
+          "schema" => "UDP",
+          "host" => "127.0.0.1",
+          "port" => 22_000 + rem(System.unique_integer([:positive]), 20_000),
+          "enabled" => true,
+          "position" => 3
+        }
+      })
+
+    source_id = McpAssertions.assert_tool_success({:ok, created})["data"]["id"]
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "delete_source", %{
+          "route_id" => ctx.route_id,
+          "source_id" => source_id
+        })
+      )
+
+    assert structured["data"]["deleted"] == true
+    assert structured["data"]["source_id"] == source_id
+  end
+end

--- a/test/e2e_mcp/tags_tools_test.exs
+++ b/test/e2e_mcp/tags_tools_test.exs
@@ -1,0 +1,53 @@
+defmodule HydraSrt.E2E.Mcp.TagsToolsTest do
+  use HydraSrt.TestSupport.McpE2ECase
+
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  test "list_tags", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(McpE2EClient.call_tool(client, "list_tags", %{}))
+
+    assert is_list(structured["data"])
+    assert Enum.any?(structured["data"], &(&1["id"] == ctx.tag_id))
+  end
+
+  test "create_tag", %{client: client, ctx: ctx} do
+    name = McpFixtures.disposable_tag_name(ctx)
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "create_tag", %{"tag" => %{"name" => name}})
+      )
+
+    assert structured["data"]["name"] == name
+  end
+
+  test "update_tag", %{client: client, ctx: ctx} do
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "update_tag", %{
+          "tag_id" => ctx.tag_id,
+          "tag" => %{"name" => "mcp-e2e-updated-tag-#{ctx.suffix}"}
+        })
+      )
+
+    assert structured["data"]["name"] == "mcp-e2e-updated-tag-#{ctx.suffix}"
+  end
+
+  test "delete_tag", %{client: client, ctx: ctx} do
+    {:ok, created} =
+      McpE2EClient.call_tool(client, "create_tag", %{
+        "tag" => %{"name" => McpFixtures.disposable_tag_name(ctx)}
+      })
+
+    tag_id = McpAssertions.assert_tool_success({:ok, created})["data"]["id"]
+
+    structured =
+      McpAssertions.assert_tool_success(
+        McpE2EClient.call_tool(client, "delete_tag", %{"tag_id" => tag_id})
+      )
+
+    assert structured["data"]["deleted"] == true
+    assert structured["data"]["tag_id"] == tag_id
+  end
+end

--- a/test/support/e2e_helpers.ex
+++ b/test/support/e2e_helpers.ex
@@ -38,6 +38,18 @@ defmodule HydraSrt.TestSupport.E2EHelpers do
     :ok
   end
 
+  def ensure_e2e_mcp_prereqs! do
+    kill_all_pipelines!()
+    ensure_native_built!()
+    ensure_api_auth_config!()
+    ensure_repo_config_for_e2e!()
+    ensure_app_started!()
+    ensure_cachex_started!()
+    ensure_repo_migrated_for_e2e!()
+    ensure_endpoint_server_started!()
+    :ok
+  end
+
   def ensure_app_started! do
     if is_pid(Process.whereis(HydraSrt.Supervisor)) and not repo_started_with_e2e_config?() do
       :ok = Application.stop(:hydra_srt)

--- a/test/support/fixtures/db_fixtures.ex
+++ b/test/support/fixtures/db_fixtures.ex
@@ -40,6 +40,10 @@ defmodule HydraSrt.DbFixtures do
     default_position = Map.get(attrs, "position") || Map.get(attrs, :position) || 0
     route_port_seed = abs(:erlang.phash2(route_id || "route")) |> rem(20_000)
 
+    unique_port =
+      10_000 + route_port_seed + default_position * 1000 +
+        rem(System.unique_integer([:positive]), 1000)
+
     attrs =
       attrs
       |> Enum.into(%{
@@ -48,7 +52,7 @@ defmodule HydraSrt.DbFixtures do
         "name" => "primary",
         "schema" => "UDP",
         "host" => "127.0.0.1",
-        "port" => 5000 + default_position + route_port_seed
+        "port" => unique_port
       })
 
     {:ok, source} = HydraSrt.Db.create_source(route_id, attrs)
@@ -60,7 +64,8 @@ defmodule HydraSrt.DbFixtures do
   """
   def destination_fixture(route, attrs \\ %{}) do
     route_id = if is_map(route), do: route["id"] || route.id, else: route
-    unique_port = 10_000 + rem(System.unique_integer([:positive]), 50_000)
+    route_port_seed = abs(:erlang.phash2(route_id || "route")) |> rem(20_000)
+    unique_port = 10_000 + route_port_seed + rem(System.unique_integer([:positive]), 1000)
 
     attrs =
       attrs

--- a/test/support/mcp_e2e_assertions.ex
+++ b/test/support/mcp_e2e_assertions.ex
@@ -1,0 +1,75 @@
+defmodule HydraSrt.TestSupport.McpE2EAssertions do
+  @moduledoc false
+
+  import ExUnit.Assertions
+
+  alias Hermes.MCP.Response, as: McpResponse
+  alias HydraSrt.TestSupport.E2EHelpers
+  alias HydraSrt.TestSupport.McpE2EClient
+
+  @spec assert_mcp_auth_rejected!(keyword()) :: :ok
+  def assert_mcp_auth_rejected!(opts \\ []) do
+    url = Keyword.get(opts, :url, McpE2EClient.mcp_url())
+    headers = Keyword.get(opts, :headers, [])
+
+    request_headers =
+      [{"accept", McpE2EClient.mcp_accept_header()}, {"content-type", "application/json"}] ++
+        headers
+
+    {:ok, status, resp_headers, body} =
+      E2EHelpers.http_raw(:post, url, request_headers, "{}")
+
+    assert status == 401
+    assert Jason.decode!(body)["error"]
+    assert header_value(resp_headers, "www-authenticate") == "Bearer"
+    :ok
+  end
+
+  @spec header_value([{term(), term()}], String.t()) :: String.t() | nil
+  def header_value(headers, name) when is_binary(name) do
+    Enum.find_value(headers, fn
+      {key, value} when is_list(key) ->
+        if String.downcase(to_string(key)) == String.downcase(name), do: to_string(value)
+
+      {key, value} when is_atom(key) ->
+        if Atom.to_string(key) == name, do: to_string(value)
+
+      {key, value} when is_binary(key) ->
+        if String.downcase(key) == String.downcase(name), do: to_string(value)
+
+      _ ->
+        nil
+    end)
+  end
+
+  @spec assert_tool_success({:ok, McpResponse.t()} | {:error, term()}) :: map()
+  def assert_tool_success(result) do
+    assert {:ok, response} = result
+    assert McpResponse.success?(response), "expected MCP tool success, got: #{inspect(response)}"
+
+    structured = structured_content(response)
+    assert is_map(structured), "expected structuredContent map, got: #{inspect(structured)}"
+    refute Map.get(structured, "error"), "unexpected tool error: #{inspect(structured)}"
+    assert Map.has_key?(structured, "data"), "expected data envelope in #{inspect(structured)}"
+    assert {:ok, _} = Jason.encode(structured)
+    structured
+  end
+
+  @spec assert_tool_responds({:ok, McpResponse.t()} | {:error, term()}) :: map()
+  def assert_tool_responds(result) do
+    assert {:ok, response} = result,
+           "expected MCP protocol success, got: #{inspect(result)}"
+
+    structured = structured_content(response)
+    assert is_map(structured), "expected structuredContent map, got: #{inspect(structured)}"
+    assert {:ok, _} = Jason.encode(structured)
+    structured
+  end
+
+  @spec structured_content(McpResponse.t()) :: map() | nil
+  def structured_content(%McpResponse{} = response) do
+    response
+    |> McpResponse.unwrap()
+    |> Map.get("structuredContent")
+  end
+end

--- a/test/support/mcp_e2e_case.ex
+++ b/test/support/mcp_e2e_case.ex
@@ -1,0 +1,45 @@
+defmodule HydraSrt.TestSupport.McpE2ECase do
+  @moduledoc false
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use ExUnit.Case, async: false
+
+      @moduletag :e2e_mcp
+
+      alias HydraSrt.Db
+      alias HydraSrt.TestSupport.E2EHelpers
+      alias HydraSrt.TestSupport.McpE2EAssertions, as: McpAssertions
+      alias HydraSrt.TestSupport.McpE2EClient
+      alias HydraSrt.TestSupport.McpE2EFixtures, as: McpFixtures
+    end
+  end
+
+  setup tags do
+    if tags[:skip_mcp_client] do
+      :ok
+    else
+      {:ok, _token, raw_token} =
+        HydraSrt.Db.create_token(%{
+          "name" =>
+            "mcp-e2e-#{System.system_time(:microsecond)}-#{System.unique_integer([:positive])}"
+        })
+
+      base_url = tags[:base_url] || HydraSrt.TestSupport.E2EHelpers.base_url()
+
+      client =
+        HydraSrt.TestSupport.McpE2EClient.start_linked!(raw_token, base_url: base_url)
+
+      ctx =
+        if tags[:skip_mcp_fixtures],
+          do: nil,
+          else: HydraSrt.TestSupport.McpE2EFixtures.seed_context!()
+
+      on_exit(fn -> HydraSrt.TestSupport.McpE2EClient.stop(client) end)
+
+      {:ok, client: client, ctx: ctx, raw_token: raw_token}
+    end
+  end
+end

--- a/test/support/mcp_e2e_client.ex
+++ b/test/support/mcp_e2e_client.ex
@@ -1,0 +1,85 @@
+defmodule HydraSrt.TestSupport.McpE2EClient.Impl do
+  @moduledoc false
+
+  use Hermes.Client,
+    name: "HydraSRT MCP E2E",
+    version: "1.0.0",
+    protocol_version: "2025-03-26",
+    capabilities: []
+end
+
+defmodule HydraSrt.TestSupport.McpE2EClient do
+  @moduledoc false
+
+  alias Hermes.Client.Base, as: ClientBase
+  alias HydraSrt.TestSupport.E2EHelpers
+  alias HydraSrt.TestSupport.McpE2EClient.Impl
+
+  @accept "application/json, text/event-stream"
+
+  @spec start_linked!(String.t(), keyword()) :: atom()
+  def start_linked!(raw_token, opts \\ []) when is_binary(raw_token) do
+    base_url = Keyword.get(opts, :base_url, E2EHelpers.base_url())
+    name = Keyword.get(opts, :name, unique_name())
+
+    {:ok, _supervisor} =
+      Impl.start_link(
+        client_name: name,
+        client_info: %{"name" => "HydraSRT MCP E2E", "version" => "1.0.0"},
+        capabilities: %{},
+        protocol_version: "2025-03-26",
+        transport:
+          {:streamable_http,
+           base_url: base_url,
+           mcp_path: "/mcp",
+           headers: %{"authorization" => "Bearer #{raw_token}"}}
+      )
+
+    wait_until_initialized!(name)
+    name
+  end
+
+  @spec stop(atom()) :: :ok
+  def stop(client) do
+    _ = ClientBase.close(client)
+    :ok
+  end
+
+  @spec call_tool(atom(), String.t(), map() | nil, keyword()) ::
+          {:ok, Hermes.MCP.Response.t()} | {:error, term()}
+  def call_tool(client, name, args \\ nil, opts \\ []),
+    do: ClientBase.call_tool(client, name, args, opts)
+
+  @spec list_tools(atom(), keyword()) :: {:ok, Hermes.MCP.Response.t()} | {:error, term()}
+  def list_tools(client, opts \\ []), do: ClientBase.list_tools(client, opts)
+
+  @spec ping(atom(), keyword()) :: :pong | {:error, term()}
+  def ping(client, opts \\ []), do: ClientBase.ping(client, opts)
+
+  @spec mcp_url(keyword()) :: String.t()
+  def mcp_url(opts \\ []) do
+    base_url = Keyword.get(opts, :base_url, E2EHelpers.base_url())
+    base_url <> "/mcp"
+  end
+
+  @spec mcp_accept_header() :: String.t()
+  def mcp_accept_header, do: @accept
+
+  def unique_name do
+    :"mcp_e2e_client_#{System.unique_integer([:positive])}"
+  end
+
+  def wait_until_initialized!(client, attempts \\ 50) do
+    case ClientBase.ping(client, timeout: 5_000) do
+      :pong ->
+        client
+
+      {:error, _reason} when attempts > 0 ->
+        Process.sleep(100)
+        wait_until_initialized!(client, attempts - 1)
+
+      other ->
+        raise "MCP E2E client failed to initialize: #{inspect(other)}"
+    end
+  end
+end

--- a/test/support/mcp_e2e_fixtures.ex
+++ b/test/support/mcp_e2e_fixtures.ex
@@ -1,0 +1,71 @@
+defmodule HydraSrt.TestSupport.McpE2EFixtures do
+  @moduledoc false
+
+  import HydraSrt.DbFixtures
+
+  alias HydraSrt.Db
+  alias HydraSrt.Nodes
+
+  @type context :: %{
+          suffix: String.t(),
+          route_id: String.t(),
+          source_id: String.t(),
+          source2_id: String.t(),
+          destination_id: String.t(),
+          tag_id: String.t(),
+          interface_id: String.t(),
+          node_id: String.t(),
+          loopback_sys_name: String.t()
+        }
+
+  @spec seed_context!() :: context()
+  def seed_context! do
+    suffix = Integer.to_string(System.unique_integer([:positive]))
+    route = route_fixture(%{"name" => "mcp-e2e-route-#{suffix}", "enabled" => false})
+    source = source_fixture(route, %{"name" => "mcp-e2e-source-1", "position" => 0})
+    source2 = source_fixture(route, %{"name" => "mcp-e2e-source-2", "position" => 1})
+    destination = destination_fixture(route, %{"name" => "mcp-e2e-destination-#{suffix}"})
+    {:ok, tag} = Db.create_tag(%{"name" => "mcp-e2e-tag-#{suffix}"})
+
+    {:ok, interface} =
+      Db.create_interface(%{
+        "name" => "mcp-e2e-interface-#{suffix}",
+        "sys_name" => "mcp-e2e-lo-#{suffix}",
+        "ip" => "127.0.0.1",
+        "enabled" => true
+      })
+
+    stats = Nodes.self_stats()
+    node_id = to_string(stats[:host] || stats["host"] || node())
+
+    %{
+      suffix: suffix,
+      route_id: route["id"],
+      source_id: source["id"],
+      source2_id: source2["id"],
+      destination_id: destination["id"],
+      tag_id: tag.id,
+      interface_id: interface["id"],
+      node_id: node_id,
+      loopback_sys_name: loopback_sys_name()
+    }
+  end
+
+  @spec loopback_sys_name() :: String.t()
+  def loopback_sys_name do
+    case :os.type() do
+      {:unix, :darwin} -> "lo0"
+      _ -> "lo"
+    end
+  end
+
+  @spec disposable_route_name(context()) :: String.t()
+  def disposable_route_name(%{suffix: suffix}), do: "mcp-e2e-disposable-route-#{suffix}"
+
+  @spec disposable_tag_name(context()) :: String.t()
+  def disposable_tag_name(%{suffix: suffix}), do: "mcp-e2e-disposable-tag-#{suffix}"
+
+  @spec disposable_interface_name(context()) :: String.t()
+  def disposable_interface_name(%{suffix: suffix}),
+    do: "mcp-e2e-disposable-interface-#{suffix}"
+end

--- a/test/support/mcp_e2e_probe_case.ex
+++ b/test/support/mcp_e2e_probe_case.ex
@@ -1,0 +1,45 @@
+defmodule HydraSrt.TestSupport.McpE2EProbeCase do
+  @moduledoc false
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use ExUnit.Case, async: false
+
+      @moduletag :mcp_probe
+
+      alias HydraSrt.Db
+      alias HydraSrt.TestSupport.E2EHelpers
+      alias HydraSrt.TestSupport.McpE2EAssertions, as: McpAssertions
+      alias HydraSrt.TestSupport.McpE2EClient
+      alias HydraSrt.TestSupport.McpE2EFixtures, as: McpFixtures
+    end
+  end
+
+  setup tags do
+    if tags[:skip_mcp_client] do
+      :ok
+    else
+      {:ok, _token, raw_token} =
+        HydraSrt.Db.create_token(%{
+          "name" =>
+            "mcp-e2e-#{System.system_time(:microsecond)}-#{System.unique_integer([:positive])}"
+        })
+
+      base_url = tags[:base_url] || HydraSrt.TestSupport.E2EHelpers.base_url()
+
+      client =
+        HydraSrt.TestSupport.McpE2EClient.start_linked!(raw_token, base_url: base_url)
+
+      ctx =
+        if tags[:skip_mcp_fixtures],
+          do: nil,
+          else: HydraSrt.TestSupport.McpE2EFixtures.seed_context!()
+
+      on_exit(fn -> HydraSrt.TestSupport.McpE2EClient.stop(client) end)
+
+      {:ok, client: client, ctx: ctx, raw_token: raw_token}
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,14 +2,24 @@ ExUnit.start()
 
 test_args = System.argv()
 
-e2e_mode_enabled? =
+cli_only_or_include? = fn tag ->
+  Enum.chunk_every(test_args, 2, 1, :discard)
+  |> Enum.any?(fn
+    ["--only", candidate] -> candidate == tag
+    ["--include", candidate] -> candidate == tag
+    _ -> false
+  end)
+end
+
+e2e_mcp_mode_enabled? =
+  System.get_env("E2E_MCP") == "true" or
+    cli_only_or_include?.("e2e_mcp") or cli_only_or_include?.("mcp_probe")
+
+e2e_route_mode_enabled? =
   System.get_env("E2E") == "true" or
-    Enum.chunk_every(test_args, 2, 1, :discard)
-    |> Enum.any?(fn
-      ["--only", tag] -> String.starts_with?(tag, "e2e")
-      ["--include", tag] -> String.starts_with?(tag, "e2e")
-      _ -> false
-    end)
+    cli_only_or_include?.("e2e") or cli_only_or_include?.("encrypted")
+
+shared_http_e2e_mode? = e2e_route_mode_enabled? or e2e_mcp_mode_enabled?
 
 # Opt-in helpers for debugging hangs:
 # - TRACE=true       -> prints every test name as it runs
@@ -43,11 +53,18 @@ end
 ]
 |> Enum.each(&Code.require_file/1)
 
-excludes = []
+excludes = [mcp_probe: true]
 
 excludes =
-  if not e2e_mode_enabled? do
+  if not e2e_route_mode_enabled? do
     [e2e: true] ++ excludes
+  else
+    excludes
+  end
+
+excludes =
+  if not e2e_mcp_mode_enabled? do
+    [e2e_mcp: true] ++ excludes
   else
     excludes
   end
@@ -63,7 +80,7 @@ if excludes != [] do
   ExUnit.configure(exclude: excludes)
 end
 
-if not e2e_mode_enabled? do
+if not shared_http_e2e_mode? do
   # Unit tests use SQL Sandbox.
   if Code.ensure_loaded?(HydraSrt.Repo) and function_exported?(HydraSrt.Repo, :__adapter__, 0) do
     case Process.whereis(HydraSrt.Repo) do
@@ -76,12 +93,14 @@ if not e2e_mode_enabled? do
   end
 end
 
-if e2e_mode_enabled? do
+if shared_http_e2e_mode? do
   # One shared HTTP endpoint + one SQLite file: parallel ExUnit cases contend on DB
   # locks and route lifecycle, causing flaky "database is locked" / pipeline timeouts.
   ExUnit.configure(max_cases: 1)
+end
 
-  # E2E suite needs the real HTTP server + API auth
+if e2e_route_mode_enabled? do
+  # Route E2E suite needs ffmpeg/SRT and pipeline cleanup.
   HydraSrt.TestSupport.E2EHelpers.ensure_e2e_prereqs!()
 
   if not HydraSrt.TestSupport.E2EHelpers.ffmpeg_supports_srt_encryption?() do
@@ -91,6 +110,12 @@ if e2e_mode_enabled? do
 
     ExUnit.configure(exclude: [:encrypted])
   end
+
+  ExUnit.after_suite(fn _ -> HydraSrt.TestSupport.E2EHelpers.kill_all_pipelines!() end)
+end
+
+if e2e_mcp_mode_enabled? do
+  HydraSrt.TestSupport.E2EHelpers.ensure_e2e_mcp_prereqs!()
 
   ExUnit.after_suite(fn _ -> HydraSrt.TestSupport.E2EHelpers.kill_all_pipelines!() end)
 end


### PR DESCRIPTION
Introduce opt-in ExUnit e2e_mcp tests over Hermes Streamable HTTP for /mcp, covering auth, protocol, and all curated MCP tools. Add CI job and make target, Peri-compatible tool input schemas, MCP probe timeout tuning, and fixture hardening for bind_port and token name uniqueness.